### PR TITLE
Implement "Append" & "Prepend" instead of "Add" for element processing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "html-streaming-editor"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 authors = [":kelko: <kelko@me.com>"]
 repository = "https://github.com/kelko/html-streaming-editor"

--- a/README.md
+++ b/README.md
@@ -54,15 +54,18 @@ Currently supported element processing commands:
 - `CLEAR-CONTENT`: clears all children from the previously selected elements
 - `SET-ATTR`: Sets a given attribute to a specified value
 - `SET-TEXT-CONTENT`: removes previous children and replaces it with exactly one given text child
-- `ADD-TEXT-CONTENT`: appends a new text child
-- `ADD-COMMENT`: appends a new comment child
-- `ADD-ELEMENT`: appends a new tag/element child
+- `APPEND-TEXT-CONTENT`: appends a new text child
+- `APPEND-COMMENT`: appends a new comment child
+- `APPEND-ELEMENT`: appends a new tag/element child
+- `PREPEND-TEXT-CONTENT`: prepends a new text child
+- `PREPEND-COMMENT`: prepends a new comment child
+- `PREPEND-ELEMENT`: prepends a new tag/element child
 - `REPLACE`: replace all elements matching a CSS selector with new elements (alias: `MAP`)
 
 Currently supported element creating commands:
 
-- `CREATE-ELEMENT`: creates a new, empty element, mainly in combination with `ADD-ELEMENT` or `REPLACE` (alias: `NEW`)
-- `LOAD-FILE`: reads a DOM from a different file, mainly in combination with `ADD-ELEMENT` or `REPLACE` (alias: `SOURCE`)
+- `CREATE-ELEMENT`: creates a new, empty element, mainly in combination with `APPEND-ELEMENT`, `PREPEND-ELEMENT` or `REPLACE` (alias: `NEW`)
+- `LOAD-FILE`: reads a DOM from a different file, mainly in combination with `APPEND-ELEMENT`,  `PREPEND-ELEMENT` or `REPLACE` (alias: `SOURCE`)
 - `QUERY-REPLACED`: returns children matching the CSS selector of those elements meant to be replaced, only combination with or `REPLACE` (alias: `KEEP`)
 
 Currently supported string-value creating commands:
@@ -70,8 +73,8 @@ Currently supported string-value creating commands:
 - `USE-ELEMENT`: returns the currently selected element for a sub-pipeline, mainly in combination with "string value producing pipelines" (alias: `THIS`)
 - `USE-PARENT`: returns the parent of the currently selected element for a sub-pipeline, mainly in combination with "string value producing pipelines" (alias: `PARENT`)
 - `QUERY-ELEMENT`: runs a query on the currently selected element for a sub-pipeline, without detaching target element from HTML tree unlike `EXTRACT-ELEMENT`
-- `QUERY-PARENT`: runs a query on the parent of the currently selected element for a sub-pipeline, without detaching target element from HTML tree unlike `EXTRACT-ELEMENT`
-- `QUERY-ROOT`: runs a query on the root of the currently selected element for a sub-pipeline, without detaching target element from HTML tree unlike `EXTRACT-ELEMENT`
+- `QUERY-PARENT`: runs a query on the parent of the currently selected element for a sub-pipeline
+- `QUERY-ROOT`: runs a query on the root of the currently selected element for a sub-pipeline
 - `GET-ATTR`: returns the value of an attribute of the currently selected element for a string-value producing pipelines
 - `GET-TEXT-CONTENT`: returns the text content of the currently selected element for a string-value producing pipelines
 - `REGEX-REPLACE`: runs a RegEx-based value replacements on the current string value of the pipeline
@@ -114,13 +117,13 @@ hse -i index.html 'ONLY{main, .main} | WITHOUT{script}'
 hse -i index.html 'MAP{.placeholder ↤ SOURCE{"other.html"} | ONLY{div.content} }'
 
 # add a new <meta name="version" value=""> element to <head> with git version info 
-hse -i index.html "WITH{head ↦ ADD-ELEMENT{ NEW{meta} | SET-ATTR{name ↤ 'version'} | SET-ATTR{content ↤ '`git describe --tags`'}  } }"
+hse -i index.html "WITH{head ↦ APPEND-ELEMENT{ NEW{meta} | SET-ATTR{name ↤ 'version'} | SET-ATTR{content ↤ '`git describe --tags`'}  } }"
 
 # add a new comment to <body> with git version info
-hse -i index.html "WITH{body ↦ ADD-COMMENT{'`git describe --tags`'}}"
+hse -i index.html "WITH{body ↦ APPEND-COMMENT{'`git describe --tags`'}}"
 
 # add an RDF <meta name="dc:title"> with same content as <title>
-hse -i input.html "WITH{head ↦ ADD-ELEMENT{ NEW{meta} | SET-ATTR{name ↤ 'dc:title' } } | WITH{meta[name='dc:title'] ↦ SET-ATTR{content ↤ QUERY-PARENT{title} | GET-TEXT-CONTENT } } }"
+hse -i input.html "WITH{head ↦ APPEND-ELEMENT{ NEW{meta} | SET-ATTR{name ↤ 'dc:title' } } | WITH{meta[name='dc:title'] ↦ SET-ATTR{content ↤ QUERY-PARENT{title} | GET-TEXT-CONTENT } } }"
 
 # replace non-word characters with an underscore in an attribute
 hse -i index.html "EXTRACT-ELEMENT{#target} | SET-ATTR{data-test ↤ USE-ELEMENT | GET-ATTR{data-test} | REGEX-REPLACE{'\\W' ↤ '_'} }";"

--- a/README.md
+++ b/README.md
@@ -50,23 +50,23 @@ Currently supported element processing commands:
 - `EXTRACT-ELEMENT`: remove everything not matching the CSS selector (alias: `ONLY`)
 - `REMOVE-ELEMENT`: remove everything matching the CSS selector (alias: `WITHOUT`)
 - `FOR-EACH`: run a sub-pipeline on all sub-elements matching a CSS selector but return the previously selected elements (alias: `WITH`)
+- `REPLACE-ELEMENT`: replace all elements matching a CSS selector with new elements (alias: `MAP`)
 - `CLEAR-ATTR`: removes a given attribute from the previously selected elements  
-- `CLEAR-CONTENT`: clears all children from the previously selected elements
 - `SET-ATTR`: Sets a given attribute to a specified value
+- `CLEAR-CONTENT`: clears all children from the previously selected elements
 - `SET-TEXT-CONTENT`: removes previous children and replaces it with exactly one given text child
 - `APPEND-TEXT-CONTENT`: appends a new text child
-- `APPEND-COMMENT`: appends a new comment child
-- `APPEND-ELEMENT`: appends a new tag/element child
 - `PREPEND-TEXT-CONTENT`: prepends a new text child
+- `APPEND-COMMENT`: appends a new comment child
 - `PREPEND-COMMENT`: prepends a new comment child
+- `APPEND-ELEMENT`: appends a new tag/element child
 - `PREPEND-ELEMENT`: prepends a new tag/element child
-- `REPLACE`: replace all elements matching a CSS selector with new elements (alias: `MAP`)
 
 Currently supported element creating commands:
 
-- `CREATE-ELEMENT`: creates a new, empty element, mainly in combination with `APPEND-ELEMENT`, `PREPEND-ELEMENT` or `REPLACE` (alias: `NEW`)
-- `LOAD-FILE`: reads a DOM from a different file, mainly in combination with `APPEND-ELEMENT`,  `PREPEND-ELEMENT` or `REPLACE` (alias: `SOURCE`)
-- `QUERY-REPLACED`: returns children matching the CSS selector of those elements meant to be replaced, only combination with or `REPLACE` (alias: `KEEP`)
+- `CREATE-ELEMENT`: creates a new, empty element, mainly in combination with `APPEND-ELEMENT`, `PREPEND-ELEMENT` or `REPLACE-ELEMENT` (alias: `NEW`)
+- `LOAD-FILE`: reads a DOM from a different file, mainly in combination with `APPEND-ELEMENT`,  `PREPEND-ELEMENT` or `REPLACE-ELEMENT` (alias: `SOURCE`)
+- `QUERY-REPLACED`: returns children matching the CSS selector of those elements meant to be replaced, only combination with or `REPLACE-ELEMENT` (alias: `KEEP`)
 
 Currently supported string-value creating commands:
 
@@ -91,10 +91,10 @@ The binary is called `hse` and supports following options:
 
 ```
 USAGE:
-    hse [OPTIONS] <COMMANDS>
+    hse [OPTIONS] <PIPELINE>
 
 ARGS:
-    <COMMANDS>    Single string with the command pipeline to perform
+    <PIPELINE>  Single string with the command pipeline to perform. If it starts with an @ the rest is treated as file name to read the pipeline definition from
 
 OPTIONS:
     -h, --help               Print help information
@@ -126,5 +126,8 @@ hse -i index.html "WITH{body ↦ APPEND-COMMENT{'`git describe --tags`'}}"
 hse -i input.html "WITH{head ↦ APPEND-ELEMENT{ NEW{meta} | SET-ATTR{name ↤ 'dc:title' } } | WITH{meta[name='dc:title'] ↦ SET-ATTR{content ↤ QUERY-PARENT{title} | GET-TEXT-CONTENT } } }"
 
 # replace non-word characters with an underscore in an attribute
-hse -i index.html "EXTRACT-ELEMENT{#target} | SET-ATTR{data-test ↤ USE-ELEMENT | GET-ATTR{data-test} | REGEX-REPLACE{'\\W' ↤ '_'} }";"
+hse -i index.html "EXTRACT-ELEMENT{#target} | SET-ATTR{data-test ↤ USE-ELEMENT | GET-ATTR{data-test} | REGEX-REPLACE{'\\W' ↤ '_'} }"
+
+# run the pipeline defined in file `file.hsp` on content of `index.html`
+hse -i index.html @file.hsp
 ```

--- a/src/element_processing/command/tests.rs
+++ b/src/element_processing/command/tests.rs
@@ -244,9 +244,9 @@ fn set_text_content_from_string_for_tag_with_multiple_children() {
 }
 
 #[test]
-fn add_text_content_from_string_for_tag() {
+fn append_text_content_from_string_for_tag() {
     let command =
-        ElementProcessingCommand::AddTextContent(ValueSource::StringValue("Other Content"));
+        ElementProcessingCommand::AppendTextContent(ValueSource::StringValue("Other Content"));
 
     let root = load_inline_html(r#"<div data-test="foo" class="bar">Some Content</div>"#);
 
@@ -261,8 +261,8 @@ fn add_text_content_from_string_for_tag() {
 }
 
 #[test]
-fn add_text_content_from_string_for_empty_tag() {
-    let command = ElementProcessingCommand::AddTextContent(ValueSource::SubPipeline(
+fn append_text_content_from_string_for_empty_tag() {
+    let command = ElementProcessingCommand::AppendTextContent(ValueSource::SubPipeline(
         StringValueCreatingPipeline::new(
             ElementSelectingCommand::UseElement,
             ValueExtractingCommand::GetAttribute("data-test"),
@@ -282,9 +282,9 @@ fn add_text_content_from_string_for_empty_tag() {
 }
 
 #[test]
-fn add_text_content_from_attr_for_empty_tag() {
+fn append_text_content_from_attr_for_empty_tag() {
     let command =
-        ElementProcessingCommand::AddTextContent(ValueSource::StringValue("Other Content"));
+        ElementProcessingCommand::AppendTextContent(ValueSource::StringValue("Other Content"));
 
     let root = load_inline_html(r#"<div data-test="foo" class="bar"></div>"#);
 
@@ -299,9 +299,9 @@ fn add_text_content_from_attr_for_empty_tag() {
 }
 
 #[test]
-fn add_text_content_from_string_for_tag_with_multiple_children() {
+fn append_text_content_from_string_for_tag_with_multiple_children() {
     let command =
-        ElementProcessingCommand::AddTextContent(ValueSource::StringValue("Other Content"));
+        ElementProcessingCommand::AppendTextContent(ValueSource::StringValue("Other Content"));
 
     let root = load_inline_html(
         r#"<div data-test="foo" class="bar">Some <em>special</em> Content. <!-- rightly so --></div>"#,
@@ -320,8 +320,9 @@ fn add_text_content_from_string_for_tag_with_multiple_children() {
 }
 
 #[test]
-fn add_comment_from_string_for_tag() {
-    let command = ElementProcessingCommand::AddComment(ValueSource::StringValue("Other Content"));
+fn append_comment_from_string_for_tag() {
+    let command =
+        ElementProcessingCommand::AppendComment(ValueSource::StringValue("Other Content"));
 
     let root = load_inline_html(r#"<div data-test="foo" class="bar">Some Content</div>"#);
 
@@ -338,8 +339,9 @@ fn add_comment_from_string_for_tag() {
 }
 
 #[test]
-fn add_comment_from_string_for_empty_tag() {
-    let command = ElementProcessingCommand::AddComment(ValueSource::StringValue("Other Content"));
+fn append_comment_from_string_for_empty_tag() {
+    let command =
+        ElementProcessingCommand::AppendComment(ValueSource::StringValue("Other Content"));
 
     let root = load_inline_html(r#"<div data-test="foo" class="bar"></div>"#);
 
@@ -354,8 +356,8 @@ fn add_comment_from_string_for_empty_tag() {
 }
 
 #[test]
-fn add_comment_from_attr_for_empty_tag() {
-    let command = ElementProcessingCommand::AddComment(ValueSource::SubPipeline(
+fn append_comment_from_attr_for_empty_tag() {
+    let command = ElementProcessingCommand::AppendComment(ValueSource::SubPipeline(
         StringValueCreatingPipeline::new(
             ElementSelectingCommand::UseElement,
             ValueExtractingCommand::GetAttribute("data-test"),
@@ -375,8 +377,9 @@ fn add_comment_from_attr_for_empty_tag() {
 }
 
 #[test]
-fn add_comment_from_string_for_tag_with_multiple_children() {
-    let command = ElementProcessingCommand::AddComment(ValueSource::StringValue("Other Content"));
+fn append_comment_from_string_for_tag_with_multiple_children() {
+    let command =
+        ElementProcessingCommand::AppendComment(ValueSource::StringValue("Other Content"));
 
     let root = load_inline_html(
         r#"<div data-test="foo" class="bar"><!-- rightly so -->Some <em>special</em> Content.</div>"#,
@@ -391,6 +394,25 @@ fn add_comment_from_string_for_tag_with_multiple_children() {
         String::from(
             r#"<div class="bar" data-test="foo"><!-- rightly so -->Some <em>special</em> Content.<!-- Other Content --></div>"#
         )
+    );
+}
+
+#[test]
+fn append_element_from_create_for_tag() {
+    let command = ElementProcessingCommand::AppendElement(ElementCreatingPipeline::new(
+        ElementCreatingCommand::CreateElement("div"),
+        None,
+    ));
+
+    let root = load_inline_html(r#"<div data-test="foo" class="bar">Some Content</div>"#);
+
+    let mut result = command.execute(&vec![rctree::Node::clone(&root)]).unwrap();
+
+    assert_eq!(result.len(), 1);
+    let first_result = result.pop().unwrap();
+    assert_eq!(
+        first_result.outer_html(),
+        String::from(r#"<div class="bar" data-test="foo">Some Content<div></div></div>"#)
     );
 }
 
@@ -415,25 +437,6 @@ fn for_each_on_ul() {
     assert_eq!(
         first_result.outer_html(),
         String::from(r#"<ul><li data-test="x">1</li><li data-test="x">2</li></ul>"#)
-    );
-}
-
-#[test]
-fn add_element_from_create_for_tag() {
-    let command = ElementProcessingCommand::AddElement(ElementCreatingPipeline::new(
-        ElementCreatingCommand::CreateElement("div"),
-        None,
-    ));
-
-    let root = load_inline_html(r#"<div data-test="foo" class="bar">Some Content</div>"#);
-
-    let mut result = command.execute(&vec![rctree::Node::clone(&root)]).unwrap();
-
-    assert_eq!(result.len(), 1);
-    let first_result = result.pop().unwrap();
-    assert_eq!(
-        first_result.outer_html(),
-        String::from(r#"<div class="bar" data-test="foo">Some Content<div></div></div>"#)
     );
 }
 
@@ -518,5 +521,178 @@ fn replace_element_using_query_replaced() {
         String::from(
             r#"<body><p>Content</p><p>levels</p><div class="stay">This will be kept</div></body>"#
         )
+    );
+}
+
+#[test]
+fn prepend_text_content_from_string_for_tag() {
+    let command =
+        ElementProcessingCommand::PrependTextContent(ValueSource::StringValue("Other Content"));
+
+    let root = load_inline_html(r#"<div data-test="foo" class="bar">Some Content</div>"#);
+
+    let mut result = command.execute(&vec![rctree::Node::clone(&root)]).unwrap();
+
+    assert_eq!(result.len(), 1);
+    let first_result = result.pop().unwrap();
+    assert_eq!(
+        first_result.outer_html(),
+        String::from(r#"<div class="bar" data-test="foo">Other ContentSome Content</div>"#)
+    );
+}
+
+#[test]
+fn prepend_text_content_from_string_for_empty_tag() {
+    let command = ElementProcessingCommand::PrependTextContent(ValueSource::SubPipeline(
+        StringValueCreatingPipeline::new(
+            ElementSelectingCommand::UseElement,
+            ValueExtractingCommand::GetAttribute("data-test"),
+        ),
+    ));
+
+    let root = load_inline_html(r#"<div data-test="foo" class="bar"></div>"#);
+
+    let mut result = command.execute(&vec![rctree::Node::clone(&root)]).unwrap();
+
+    assert_eq!(result.len(), 1);
+    let first_result = result.pop().unwrap();
+    assert_eq!(
+        first_result.outer_html(),
+        String::from(r#"<div class="bar" data-test="foo">foo</div>"#)
+    );
+}
+
+#[test]
+fn prepend_text_content_from_attr_for_empty_tag() {
+    let command =
+        ElementProcessingCommand::PrependTextContent(ValueSource::StringValue("Other Content"));
+
+    let root = load_inline_html(r#"<div data-test="foo" class="bar"></div>"#);
+
+    let mut result = command.execute(&vec![rctree::Node::clone(&root)]).unwrap();
+
+    assert_eq!(result.len(), 1);
+    let first_result = result.pop().unwrap();
+    assert_eq!(
+        first_result.outer_html(),
+        String::from(r#"<div class="bar" data-test="foo">Other Content</div>"#)
+    );
+}
+
+#[test]
+fn prepend_text_content_from_string_for_tag_with_multiple_children() {
+    let command =
+        ElementProcessingCommand::PrependTextContent(ValueSource::StringValue("Other Content"));
+
+    let root = load_inline_html(
+        r#"<div data-test="foo" class="bar">Some <em>special</em> Content. <!-- rightly so --></div>"#,
+    );
+
+    let mut result = command.execute(&vec![rctree::Node::clone(&root)]).unwrap();
+
+    assert_eq!(result.len(), 1);
+    let first_result = result.pop().unwrap();
+    assert_eq!(
+        first_result.outer_html(),
+        String::from(
+            r#"<div class="bar" data-test="foo">Other ContentSome <em>special</em> Content. <!-- rightly so --></div>"#
+        )
+    );
+}
+
+#[test]
+fn prepend_comment_from_string_for_tag() {
+    let command =
+        ElementProcessingCommand::PrependComment(ValueSource::StringValue("Other Content"));
+
+    let root = load_inline_html(r#"<div data-test="foo" class="bar">Some Content</div>"#);
+
+    let mut result = command.execute(&vec![rctree::Node::clone(&root)]).unwrap();
+
+    assert_eq!(result.len(), 1);
+    let first_result = result.pop().unwrap();
+    assert_eq!(
+        first_result.outer_html(),
+        String::from(
+            r#"<div class="bar" data-test="foo"><!-- Other Content -->Some Content</div>"#
+        )
+    );
+}
+
+#[test]
+fn prepend_comment_from_string_for_empty_tag() {
+    let command =
+        ElementProcessingCommand::PrependComment(ValueSource::StringValue("Other Content"));
+
+    let root = load_inline_html(r#"<div data-test="foo" class="bar"></div>"#);
+
+    let mut result = command.execute(&vec![rctree::Node::clone(&root)]).unwrap();
+
+    assert_eq!(result.len(), 1);
+    let first_result = result.pop().unwrap();
+    assert_eq!(
+        first_result.outer_html(),
+        String::from(r#"<div class="bar" data-test="foo"><!-- Other Content --></div>"#)
+    );
+}
+
+#[test]
+fn prepend_comment_from_attr_for_empty_tag() {
+    let command = ElementProcessingCommand::PrependComment(ValueSource::SubPipeline(
+        StringValueCreatingPipeline::new(
+            ElementSelectingCommand::UseElement,
+            ValueExtractingCommand::GetAttribute("data-test"),
+        ),
+    ));
+
+    let root = load_inline_html(r#"<div data-test="foo" class="bar"></div>"#);
+
+    let mut result = command.execute(&vec![rctree::Node::clone(&root)]).unwrap();
+
+    assert_eq!(result.len(), 1);
+    let first_result = result.pop().unwrap();
+    assert_eq!(
+        first_result.outer_html(),
+        String::from(r#"<div class="bar" data-test="foo"><!-- foo --></div>"#)
+    );
+}
+
+#[test]
+fn prepend_comment_from_string_for_tag_with_multiple_children() {
+    let command =
+        ElementProcessingCommand::PrependComment(ValueSource::StringValue("Other Content"));
+
+    let root = load_inline_html(
+        r#"<div data-test="foo" class="bar"><!-- rightly so -->Some <em>special</em> Content.</div>"#,
+    );
+
+    let mut result = command.execute(&vec![rctree::Node::clone(&root)]).unwrap();
+
+    assert_eq!(result.len(), 1);
+    let first_result = result.pop().unwrap();
+    assert_eq!(
+        first_result.outer_html(),
+        String::from(
+            r#"<div class="bar" data-test="foo"><!-- Other Content --><!-- rightly so -->Some <em>special</em> Content.</div>"#
+        )
+    );
+}
+
+#[test]
+fn prepend_element_from_create_for_tag() {
+    let command = ElementProcessingCommand::PrependElement(ElementCreatingPipeline::new(
+        ElementCreatingCommand::CreateElement("div"),
+        None,
+    ));
+
+    let root = load_inline_html(r#"<div data-test="foo" class="bar">Some Content</div>"#);
+
+    let mut result = command.execute(&vec![rctree::Node::clone(&root)]).unwrap();
+
+    assert_eq!(result.len(), 1);
+    let first_result = result.pop().unwrap();
+    assert_eq!(
+        first_result.outer_html(),
+        String::from(r#"<div class="bar" data-test="foo"><div></div>Some Content</div>"#)
     );
 }

--- a/src/parsing/mod.rs
+++ b/src/parsing/mod.rs
@@ -113,24 +113,33 @@ parser! {
             = "SET-ATTR{" whitespace()? a:identifier() whitespace()? assign_marker() whitespace()? v:value_source() whitespace()? "}" { ElementProcessingCommand::SetAttribute(a, v) }
         rule set_text_content_command() -> ElementProcessingCommand<'input>
             = "SET-TEXT-CONTENT{" whitespace()? (assign_marker() whitespace()?)? v:value_source() whitespace()? "}" { ElementProcessingCommand::SetTextContent(v) }
-        rule add_text_content_command() -> ElementProcessingCommand<'input>
-            = "ADD-TEXT-CONTENT{" whitespace()? (assign_marker() whitespace()?)? v:value_source() whitespace()? "}" { ElementProcessingCommand::AddTextContent(v) }
-        rule add_comment_command() -> ElementProcessingCommand<'input>
-            = "ADD-COMMENT{" whitespace()? (assign_marker() whitespace()?)? v:value_source() whitespace()? "}" { ElementProcessingCommand::AddComment(v) }
-        rule add_element_command() -> ElementProcessingCommand<'input>
-            = "ADD-ELEMENT{" whitespace()? (assign_marker() whitespace()?)? sp:element_creating_pipeline() whitespace()?  "}" { ElementProcessingCommand::AddElement(sp) }
+        rule append_text_content_command() -> ElementProcessingCommand<'input>
+            = "APPEND-TEXT-CONTENT{" whitespace()? (assign_marker() whitespace()?)? v:value_source() whitespace()? "}" { ElementProcessingCommand::AppendTextContent(v) }
+        rule append_comment_command() -> ElementProcessingCommand<'input>
+            = "APPEND-COMMENT{" whitespace()? (assign_marker() whitespace()?)? v:value_source() whitespace()? "}" { ElementProcessingCommand::AppendComment(v) }
+        rule append_element_command() -> ElementProcessingCommand<'input>
+            = "APPEND-ELEMENT{" whitespace()? (assign_marker() whitespace()?)? sp:element_creating_pipeline() whitespace()?  "}" { ElementProcessingCommand::AppendElement(sp) }
+        rule prepend_text_content_command() -> ElementProcessingCommand<'input>
+            = "PREPEND-TEXT-CONTENT{" whitespace()? (assign_marker() whitespace()?)? v:value_source() whitespace()? "}" { ElementProcessingCommand::PrependTextContent(v) }
+        rule prepend_comment_command() -> ElementProcessingCommand<'input>
+            = "PREPEND-COMMENT{" whitespace()? (assign_marker() whitespace()?)? v:value_source() whitespace()? "}" { ElementProcessingCommand::PrependComment(v) }
+        rule prepend_element_command() -> ElementProcessingCommand<'input>
+            = "PREPEND-ELEMENT{" whitespace()? (assign_marker() whitespace()?)? sp:element_creating_pipeline() whitespace()?  "}" { ElementProcessingCommand::PrependElement(sp) }
         pub(super) rule element_processing_command() -> ElementProcessingCommand<'input>
-            = extract_element_command()
-            / remove_element_command()
-            / for_each_command()
-            / clear_attr_command()
-            / clear_content_command()
-            / set_attr_command()
-            / set_text_content_command()
-            / add_text_content_command()
-            / add_comment_command()
-            / add_element_command()
+            = for_each_command()
             / replace_element_command()
+            / extract_element_command()
+            / remove_element_command()
+            / clear_attr_command()
+            / set_attr_command()
+            / clear_content_command()
+            / set_text_content_command()
+            / append_text_content_command()
+            / append_comment_command()
+            / append_element_command()
+            / prepend_text_content_command()
+            / prepend_comment_command()
+            / prepend_element_command()
 
         rule create_element_command() -> ElementCreatingCommand<'input>
             = ("CREATE-ELEMENT"/"NEW") "{" whitespace()? n:identifier() whitespace()? "}" { ElementCreatingCommand::CreateElement(n)}

--- a/src/parsing/tests.rs
+++ b/src/parsing/tests.rs
@@ -256,82 +256,82 @@ fn parse_set_text_content_by_string_with_ascii_arrow() {
 }
 
 #[test]
-fn parse_add_text_content_by_string() {
-    let parsed = super::grammar::element_processing_command("ADD-TEXT-CONTENT{'some text'}");
+fn parse_append_text_content_by_string() {
+    let parsed = super::grammar::element_processing_command("APPEND-TEXT-CONTENT{'some text'}");
     assert_eq!(
         parsed,
-        Ok(ElementProcessingCommand::AddTextContent(
+        Ok(ElementProcessingCommand::AppendTextContent(
             ValueSource::StringValue("some text")
         ))
     );
 }
 
 #[test]
-fn parse_add_text_content_by_string_with_arrow() {
-    let parsed = super::grammar::element_processing_command("ADD-TEXT-CONTENT{ ↤ 'some text'}");
+fn parse_append_text_content_by_string_with_arrow() {
+    let parsed = super::grammar::element_processing_command("APPEND-TEXT-CONTENT{ ↤ 'some text'}");
     assert_eq!(
         parsed,
-        Ok(ElementProcessingCommand::AddTextContent(
+        Ok(ElementProcessingCommand::AppendTextContent(
             ValueSource::StringValue("some text")
         ))
     );
 }
 
 #[test]
-fn parse_add_text_content_by_sub_pipeline() {
+fn parse_append_text_content_by_sub_pipeline() {
     let constructed_pipeline = format!(
-        "ADD-TEXT-CONTENT{{ {} }}",
+        "APPEND-TEXT-CONTENT{{ {} }}",
         EXEMPLARY_SUB_PIPELINE_DEFINITION
     );
     let parsed = super::grammar::element_processing_command(&constructed_pipeline);
 
     assert_eq!(
         parsed,
-        Ok(ElementProcessingCommand::AddTextContent(
+        Ok(ElementProcessingCommand::AppendTextContent(
             ValueSource::SubPipeline(EXEMPLARY_SUB_PIPELINE_MODEL.clone())
         ))
     );
 }
 
 #[test]
-fn parse_add_text_content_by_string_with_ascii_arrow() {
-    let parsed = super::grammar::element_processing_command("ADD-TEXT-CONTENT{ <= 'some text'}");
+fn parse_append_text_content_by_string_with_ascii_arrow() {
+    let parsed = super::grammar::element_processing_command("APPEND-TEXT-CONTENT{ <= 'some text'}");
     assert_eq!(
         parsed,
-        Ok(ElementProcessingCommand::AddTextContent(
+        Ok(ElementProcessingCommand::AppendTextContent(
             ValueSource::StringValue("some text")
         ))
     );
 }
 
 #[test]
-fn parse_add_comment_by_string() {
-    let parsed = super::grammar::element_processing_command("ADD-COMMENT{'some text'}");
+fn parse_append_comment_by_string() {
+    let parsed = super::grammar::element_processing_command("APPEND-COMMENT{'some text'}");
     assert_eq!(
         parsed,
-        Ok(ElementProcessingCommand::AddComment(
+        Ok(ElementProcessingCommand::AppendComment(
             ValueSource::StringValue("some text")
         ))
     );
 }
 
 #[test]
-fn parse_add_comment_by_string_with_arrow() {
-    let parsed = super::grammar::element_processing_command("ADD-COMMENT{ ↤ 'some text'}");
+fn parse_append_comment_by_string_with_arrow() {
+    let parsed = super::grammar::element_processing_command("APPEND-COMMENT{ ↤ 'some text'}");
     assert_eq!(
         parsed,
-        Ok(ElementProcessingCommand::AddComment(
+        Ok(ElementProcessingCommand::AppendComment(
             ValueSource::StringValue("some text")
         ))
     );
 }
 
 #[test]
-fn parse_add_comment_by_string_with_ascii_arrow() {
-    let parsed = super::grammar::element_processing_command("ADD-COMMENT{ <= 'some text'}");
+fn parse_append_comment_by_string_with_ascii_arrow() {
+    let parsed = super::grammar::element_processing_command("APPEND-COMMENT{ <= 'some text'}");
     assert_eq!(
         parsed,
-        Ok(ElementProcessingCommand::AddComment(
+        Ok(ElementProcessingCommand::AppendComment(
             ValueSource::StringValue("some text")
         ))
     );
@@ -397,34 +397,35 @@ fn parse_for_each_with_ascii_arrow_using_set_attr() {
 }
 
 #[test]
-fn parse_add_element_using_new_alias() {
-    let parsed = super::grammar::element_processing_command("ADD-ELEMENT{NEW{div}}");
+fn parse_append_element_using_new_alias() {
+    let parsed = super::grammar::element_processing_command("APPEND-ELEMENT{NEW{div}}");
     assert_eq!(
         parsed,
-        Ok(ElementProcessingCommand::AddElement(
+        Ok(ElementProcessingCommand::AppendElement(
             ElementCreatingPipeline::new(ElementCreatingCommand::CreateElement("div"), None)
         ))
     );
 }
 
 #[test]
-fn parse_add_element_using_create() {
-    let parsed = super::grammar::element_processing_command("ADD-ELEMENT{CREATE-ELEMENT{div}}");
+fn parse_append_element_using_create() {
+    let parsed = super::grammar::element_processing_command("APPEND-ELEMENT{CREATE-ELEMENT{div}}");
     assert_eq!(
         parsed,
-        Ok(ElementProcessingCommand::AddElement(
+        Ok(ElementProcessingCommand::AppendElement(
             ElementCreatingPipeline::new(ElementCreatingCommand::CreateElement("div"), None)
         ))
     );
 }
 
 #[test]
-fn parse_add_element_using_load_file() {
-    let parsed =
-        super::grammar::element_processing_command("ADD-ELEMENT{LOAD-FILE{'tests/source.html'}}");
+fn parse_append_element_using_load_file() {
+    let parsed = super::grammar::element_processing_command(
+        "APPEND-ELEMENT{LOAD-FILE{'tests/source.html'}}",
+    );
     assert_eq!(
         parsed,
-        Ok(ElementProcessingCommand::AddElement(
+        Ok(ElementProcessingCommand::AppendElement(
             ElementCreatingPipeline::new(
                 ElementCreatingCommand::FromFile("tests/source.html"),
                 None
@@ -434,12 +435,12 @@ fn parse_add_element_using_load_file() {
 }
 
 #[test]
-fn parse_add_element_using_source() {
+fn parse_append_element_using_source() {
     let parsed =
-        super::grammar::element_processing_command("ADD-ELEMENT{SOURCE{'tests/source.html'}}");
+        super::grammar::element_processing_command("APPEND-ELEMENT{SOURCE{'tests/source.html'}}");
     assert_eq!(
         parsed,
-        Ok(ElementProcessingCommand::AddElement(
+        Ok(ElementProcessingCommand::AppendElement(
             ElementCreatingPipeline::new(
                 ElementCreatingCommand::FromFile("tests/source.html"),
                 None
@@ -449,22 +450,24 @@ fn parse_add_element_using_source() {
 }
 
 #[test]
-fn parse_add_element_with_arrow_using_create() {
-    let parsed = super::grammar::element_processing_command("ADD-ELEMENT{ ↤ CREATE-ELEMENT{div}}");
+fn parse_append_element_with_arrow_using_create() {
+    let parsed =
+        super::grammar::element_processing_command("APPEND-ELEMENT{ ↤ CREATE-ELEMENT{div}}");
     assert_eq!(
         parsed,
-        Ok(ElementProcessingCommand::AddElement(
+        Ok(ElementProcessingCommand::AppendElement(
             ElementCreatingPipeline::new(ElementCreatingCommand::CreateElement("div"), None)
         ))
     );
 }
 
 #[test]
-fn parse_add_element_with_ascii_arrow_using_create() {
-    let parsed = super::grammar::element_processing_command("ADD-ELEMENT{ <= CREATE-ELEMENT{div}}");
+fn parse_append_element_with_ascii_arrow_using_create() {
+    let parsed =
+        super::grammar::element_processing_command("APPEND-ELEMENT{ <= CREATE-ELEMENT{div}}");
     assert_eq!(
         parsed,
-        Ok(ElementProcessingCommand::AddElement(
+        Ok(ElementProcessingCommand::AppendElement(
             ElementCreatingPipeline::new(ElementCreatingCommand::CreateElement("div"), None)
         ))
     );
@@ -544,6 +547,166 @@ fn parse_replace_element_using_query_replaced_alias_keep() {
                 None
             )
         )),
+    );
+}
+
+#[test]
+fn parse_prepend_text_content_by_string() {
+    let parsed = super::grammar::element_processing_command("PREPEND-TEXT-CONTENT{'some text'}");
+    assert_eq!(
+        parsed,
+        Ok(ElementProcessingCommand::PrependTextContent(
+            ValueSource::StringValue("some text")
+        ))
+    );
+}
+
+#[test]
+fn parse_prepend_text_content_by_string_with_arrow() {
+    let parsed = super::grammar::element_processing_command("PREPEND-TEXT-CONTENT{ ↤ 'some text'}");
+    assert_eq!(
+        parsed,
+        Ok(ElementProcessingCommand::PrependTextContent(
+            ValueSource::StringValue("some text")
+        ))
+    );
+}
+
+#[test]
+fn parse_prepend_text_content_by_sub_pipeline() {
+    let constructed_pipeline = format!(
+        "PREPEND-TEXT-CONTENT{{ {} }}",
+        EXEMPLARY_SUB_PIPELINE_DEFINITION
+    );
+    let parsed = super::grammar::element_processing_command(&constructed_pipeline);
+
+    assert_eq!(
+        parsed,
+        Ok(ElementProcessingCommand::PrependTextContent(
+            ValueSource::SubPipeline(EXEMPLARY_SUB_PIPELINE_MODEL.clone())
+        ))
+    );
+}
+
+#[test]
+fn parse_prepend_text_content_by_string_with_ascii_arrow() {
+    let parsed =
+        super::grammar::element_processing_command("PREPEND-TEXT-CONTENT{ <= 'some text'}");
+    assert_eq!(
+        parsed,
+        Ok(ElementProcessingCommand::PrependTextContent(
+            ValueSource::StringValue("some text")
+        ))
+    );
+}
+
+#[test]
+fn parse_prepend_comment_by_string() {
+    let parsed = super::grammar::element_processing_command("PREPEND-COMMENT{'some text'}");
+    assert_eq!(
+        parsed,
+        Ok(ElementProcessingCommand::PrependComment(
+            ValueSource::StringValue("some text")
+        ))
+    );
+}
+
+#[test]
+fn parse_prepend_comment_by_string_with_arrow() {
+    let parsed = super::grammar::element_processing_command("PREPEND-COMMENT{ ↤ 'some text'}");
+    assert_eq!(
+        parsed,
+        Ok(ElementProcessingCommand::PrependComment(
+            ValueSource::StringValue("some text")
+        ))
+    );
+}
+
+#[test]
+fn parse_prepend_comment_by_string_with_ascii_arrow() {
+    let parsed = super::grammar::element_processing_command("PREPEND-COMMENT{ <= 'some text'}");
+    assert_eq!(
+        parsed,
+        Ok(ElementProcessingCommand::PrependComment(
+            ValueSource::StringValue("some text")
+        ))
+    );
+}
+
+#[test]
+fn parse_prepend_element_using_new_alias() {
+    let parsed = super::grammar::element_processing_command("PREPEND-ELEMENT{NEW{div}}");
+    assert_eq!(
+        parsed,
+        Ok(ElementProcessingCommand::PrependElement(
+            ElementCreatingPipeline::new(ElementCreatingCommand::CreateElement("div"), None)
+        ))
+    );
+}
+
+#[test]
+fn parse_prepend_element_using_create() {
+    let parsed = super::grammar::element_processing_command("PREPEND-ELEMENT{CREATE-ELEMENT{div}}");
+    assert_eq!(
+        parsed,
+        Ok(ElementProcessingCommand::PrependElement(
+            ElementCreatingPipeline::new(ElementCreatingCommand::CreateElement("div"), None)
+        ))
+    );
+}
+
+#[test]
+fn parse_prepend_element_using_load_file() {
+    let parsed = super::grammar::element_processing_command(
+        "PREPEND-ELEMENT{LOAD-FILE{'tests/source.html'}}",
+    );
+    assert_eq!(
+        parsed,
+        Ok(ElementProcessingCommand::PrependElement(
+            ElementCreatingPipeline::new(
+                ElementCreatingCommand::FromFile("tests/source.html"),
+                None
+            )
+        ))
+    );
+}
+
+#[test]
+fn parse_prepend_element_using_source() {
+    let parsed =
+        super::grammar::element_processing_command("PREPEND-ELEMENT{SOURCE{'tests/source.html'}}");
+    assert_eq!(
+        parsed,
+        Ok(ElementProcessingCommand::PrependElement(
+            ElementCreatingPipeline::new(
+                ElementCreatingCommand::FromFile("tests/source.html"),
+                None
+            )
+        ))
+    );
+}
+
+#[test]
+fn parse_prepend_element_with_arrow_using_create() {
+    let parsed =
+        super::grammar::element_processing_command("PREPEND-ELEMENT{ ↤ CREATE-ELEMENT{div}}");
+    assert_eq!(
+        parsed,
+        Ok(ElementProcessingCommand::PrependElement(
+            ElementCreatingPipeline::new(ElementCreatingCommand::CreateElement("div"), None)
+        ))
+    );
+}
+
+#[test]
+fn parse_prepend_element_with_ascii_arrow_using_create() {
+    let parsed =
+        super::grammar::element_processing_command("PREPEND-ELEMENT{ <= CREATE-ELEMENT{div}}");
+    assert_eq!(
+        parsed,
+        Ok(ElementProcessingCommand::PrependElement(
+            ElementCreatingPipeline::new(ElementCreatingCommand::CreateElement("div"), None)
+        ))
     );
 }
 

--- a/tests/append_element.rs
+++ b/tests/append_element.rs
@@ -1,0 +1,112 @@
+use html_streaming_editor::*;
+
+const HTML_INPUT: &str = r#"<html>
+    <head></head>
+    <body>
+        <h1>Title</h1>
+        <p id="first-para">Some first text</p>
+        <p id="second-para">Some more text, even with an <img src=""></p>
+        <p id="third-para">Third text of <abbr>HTML</abbr>, but no <abbr>CSS</abbr></p>
+        <ul id="list">
+            <li id="item-1">1</li>
+            <li id="item-2">2</li>
+            <li id="item-3">3</li>
+        </ul>
+    </body>
+</html>"#;
+
+#[test]
+fn append_simple_div_to_first_p_content() -> Result<(), StreamingEditorError> {
+    let command = "EXTRACT-ELEMENT{#first-para} | APPEND-ELEMENT{ CREATE-ELEMENT{div} }";
+
+    let mut input = Box::new(HTML_INPUT.as_bytes());
+    let mut output = Vec::new();
+    let hse = HtmlStreamingEditor::new(&mut input, &mut output);
+
+    let _ = hse.run(command)?;
+    let result_string = String::from_utf8(output).unwrap();
+
+    assert_eq!(
+        result_string,
+        String::from(r#"<p id="first-para">Some first text<div></div></p>"#)
+    );
+
+    Ok(())
+}
+
+#[test]
+fn append_two_divs_to_first_p_content() -> Result<(), StreamingEditorError> {
+    let command = "EXTRACT-ELEMENT{#first-para} | APPEND-ELEMENT{ CREATE-ELEMENT{div} } | APPEND-ELEMENT{ CREATE-ELEMENT{div} }";
+
+    let mut input = Box::new(HTML_INPUT.as_bytes());
+    let mut output = Vec::new();
+    let hse = HtmlStreamingEditor::new(&mut input, &mut output);
+
+    let _ = hse.run(command)?;
+    let result_string = String::from_utf8(output).unwrap();
+
+    assert_eq!(
+        result_string,
+        String::from(r#"<p id="first-para">Some first text<div></div><div></div></p>"#)
+    );
+
+    Ok(())
+}
+
+#[test]
+fn append_div_with_attr_to_first_p_content() -> Result<(), StreamingEditorError> {
+    let command =
+        "EXTRACT-ELEMENT{#first-para} | APPEND-ELEMENT{ CREATE-ELEMENT{div} | SET-ATTR{id ↤ 'new'} }";
+
+    let mut input = Box::new(HTML_INPUT.as_bytes());
+    let mut output = Vec::new();
+    let hse = HtmlStreamingEditor::new(&mut input, &mut output);
+
+    let _ = hse.run(command)?;
+    let result_string = String::from_utf8(output).unwrap();
+
+    assert_eq!(
+        result_string,
+        String::from(r#"<p id="first-para">Some first text<div id="new"></div></p>"#)
+    );
+
+    Ok(())
+}
+
+#[test]
+fn copy_title_to_meta_tag() -> Result<(), StreamingEditorError> {
+    let command = "FOR-EACH{head ↦ APPEND-ELEMENT{ ↤ CREATE-ELEMENT{meta} | SET-ATTR{name ↤ 'title' } } | FOR-EACH{meta[name='title'] ↦ SET-ATTR{content ↤ QUERY-PARENT{title} | GET-TEXT-CONTENT } } }";
+
+    let mut input = Box::new(
+        r#"<html>
+    <head>
+        <title>This is the title</title>
+    </head>
+    <body>
+        <h1>Title</h1>
+    </body>
+</html>"#
+            .as_bytes(),
+    );
+    let mut output = Vec::new();
+    let hse = HtmlStreamingEditor::new(&mut input, &mut output);
+
+    let _ = hse.run(command)?;
+    let result_string = String::from_utf8(output).unwrap();
+
+    assert_eq!(
+        result_string,
+        String::from(
+            r#"<html>
+    <head>
+        <title>This is the title</title>
+    <meta content="This is the title" name="title"></head>
+    <body>
+        <h1>Title</h1>
+    </body>
+</html>"#
+        )
+    );
+
+    Ok(())
+}

--- a/tests/append_text_content.rs
+++ b/tests/append_text_content.rs
@@ -16,8 +16,9 @@ const HTML_INPUT: &str = r#"<html>
 </html>"#;
 
 #[test]
-fn add_to_first_p_content() -> Result<(), StreamingEditorError> {
-    let command = "EXTRACT-ELEMENT{#first-para} | ADD-TEXT-CONTENT{'... expanded by other text'}";
+fn append_to_first_p_content() -> Result<(), StreamingEditorError> {
+    let command =
+        "EXTRACT-ELEMENT{#first-para} | APPEND-TEXT-CONTENT{'... expanded by other text'}";
 
     let mut input = Box::new(HTML_INPUT.as_bytes());
     let mut output = Vec::new();
@@ -35,9 +36,9 @@ fn add_to_first_p_content() -> Result<(), StreamingEditorError> {
 }
 
 #[test]
-fn add_escape_needing_content() -> Result<(), StreamingEditorError> {
+fn append_escape_needing_content() -> Result<(), StreamingEditorError> {
     let command =
-        "EXTRACT-ELEMENT{#first-para} | ADD-TEXT-CONTENT{' is > others < & you never know which'}";
+        "EXTRACT-ELEMENT{#first-para} | APPEND-TEXT-CONTENT{' is > others < & you never know which'}";
 
     let mut input = Box::new(HTML_INPUT.as_bytes());
     let mut output = Vec::new();
@@ -57,8 +58,8 @@ fn add_escape_needing_content() -> Result<(), StreamingEditorError> {
 }
 
 #[test]
-fn add_ul_id_as_text_to_first_para() -> Result<(), StreamingEditorError> {
-    let command = "FOR-EACH{#first-para ↦ ADD-TEXT-CONTENT{' and ul-id is: '} | ADD-TEXT-CONTENT{ QUERY-PARENT{ul} | GET-ATTR{id} } }";
+fn append_ul_id_as_text_to_first_para() -> Result<(), StreamingEditorError> {
+    let command = "FOR-EACH{#first-para ↦ APPEND-TEXT-CONTENT{' and ul-id is: '} | APPEND-TEXT-CONTENT{ QUERY-PARENT{ul} | GET-ATTR{id} } }";
 
     let mut input = Box::new(HTML_INPUT.as_bytes());
     let mut output = Vec::new();

--- a/tests/pipeline.hsp
+++ b/tests/pipeline.hsp
@@ -1,1 +1,1 @@
-WITH{head ↦ ADD-ELEMENT{ CREATE-ELEMENT{meta} | SET-ATTR{name ↤ 'foo'} | SET-ATTR{value ↤ 'added by pipeline from file'}  } }
+WITH{head ↦ APPEND-ELEMENT{ CREATE-ELEMENT{meta} | SET-ATTR{name ↤ 'foo'} | SET-ATTR{value ↤ 'added by pipeline from file'}  } }

--- a/tests/prepend_comment.rs
+++ b/tests/prepend_comment.rs
@@ -1,0 +1,60 @@
+use html_streaming_editor::*;
+
+const HTML_INPUT: &str = r#"<html>
+    <head></head>
+    <body>
+        <h1>Title</h1>
+        <p id="first-para">Some first text</p>
+        <p id="second-para">Some more text, even with an <img src=""></p>
+        <p id="third-para">Third text of <abbr>HTML</abbr>, but no <abbr>CSS</abbr></p>
+        <ul id="list">
+            <li id="item-1">1</li>
+            <li id="item-2">2</li>
+            <li id="item-3">3</li>
+        </ul>
+    </body>
+</html>"#;
+
+#[test]
+fn prepend_to_first_p_content() -> Result<(), StreamingEditorError> {
+    let command = "EXTRACT-ELEMENT{#first-para} | PREPEND-COMMENT{'followed by a comment'}";
+
+    let mut input = Box::new(HTML_INPUT.as_bytes());
+    let mut output = Vec::new();
+    let hse = HtmlStreamingEditor::new(&mut input, &mut output);
+
+    let _ = hse.run(command)?;
+    let result_string = String::from_utf8(output).unwrap();
+
+    assert_eq!(
+        result_string,
+        String::from(r#"<p id="first-para"><!-- followed by a comment -->Some first text</p>"#)
+    );
+
+    Ok(())
+}
+
+#[test]
+fn prepend_to_ul() -> Result<(), StreamingEditorError> {
+    let command = "EXTRACT-ELEMENT{ul} | PREPEND-COMMENT{'Foo'}";
+
+    let mut input = Box::new(HTML_INPUT.as_bytes());
+    let mut output = Vec::new();
+    let hse = HtmlStreamingEditor::new(&mut input, &mut output);
+
+    let _ = hse.run(command)?;
+    let result_string = String::from_utf8(output).unwrap();
+
+    assert_eq!(
+        result_string,
+        String::from(
+            r#"<ul id="list"><!-- Foo -->
+            <li id="item-1">1</li>
+            <li id="item-2">2</li>
+            <li id="item-3">3</li>
+        </ul>"#
+        )
+    );
+
+    Ok(())
+}

--- a/tests/prepend_element.rs
+++ b/tests/prepend_element.rs
@@ -1,0 +1,112 @@
+use html_streaming_editor::*;
+
+const HTML_INPUT: &str = r#"<html>
+    <head></head>
+    <body>
+        <h1>Title</h1>
+        <p id="first-para">Some first text</p>
+        <p id="second-para">Some more text, even with an <img src=""></p>
+        <p id="third-para">Third text of <abbr>HTML</abbr>, but no <abbr>CSS</abbr></p>
+        <ul id="list">
+            <li id="item-1">1</li>
+            <li id="item-2">2</li>
+            <li id="item-3">3</li>
+        </ul>
+    </body>
+</html>"#;
+
+#[test]
+fn prepend_simple_div_to_first_p_content() -> Result<(), StreamingEditorError> {
+    let command = "EXTRACT-ELEMENT{#first-para} | PREPEND-ELEMENT{ CREATE-ELEMENT{div} }";
+
+    let mut input = Box::new(HTML_INPUT.as_bytes());
+    let mut output = Vec::new();
+    let hse = HtmlStreamingEditor::new(&mut input, &mut output);
+
+    let _ = hse.run(command)?;
+    let result_string = String::from_utf8(output).unwrap();
+
+    assert_eq!(
+        result_string,
+        String::from(r#"<p id="first-para"><div></div>Some first text</p>"#)
+    );
+
+    Ok(())
+}
+
+#[test]
+fn prepend_two_divs_to_first_p_content() -> Result<(), StreamingEditorError> {
+    let command = "EXTRACT-ELEMENT{#first-para} | PREPEND-ELEMENT{ CREATE-ELEMENT{div} } | PREPEND-ELEMENT{ CREATE-ELEMENT{div} }";
+
+    let mut input = Box::new(HTML_INPUT.as_bytes());
+    let mut output = Vec::new();
+    let hse = HtmlStreamingEditor::new(&mut input, &mut output);
+
+    let _ = hse.run(command)?;
+    let result_string = String::from_utf8(output).unwrap();
+
+    assert_eq!(
+        result_string,
+        String::from(r#"<p id="first-para"><div></div><div></div>Some first text</p>"#)
+    );
+
+    Ok(())
+}
+
+#[test]
+fn prepend_div_with_attr_to_first_p_content() -> Result<(), StreamingEditorError> {
+    let command =
+        "EXTRACT-ELEMENT{#first-para} | PREPEND-ELEMENT{ CREATE-ELEMENT{div} | SET-ATTR{id ↤ 'new'} }";
+
+    let mut input = Box::new(HTML_INPUT.as_bytes());
+    let mut output = Vec::new();
+    let hse = HtmlStreamingEditor::new(&mut input, &mut output);
+
+    let _ = hse.run(command)?;
+    let result_string = String::from_utf8(output).unwrap();
+
+    assert_eq!(
+        result_string,
+        String::from(r#"<p id="first-para"><div id="new"></div>Some first text</p>"#)
+    );
+
+    Ok(())
+}
+
+#[test]
+fn copy_title_to_meta_tag() -> Result<(), StreamingEditorError> {
+    let command = "FOR-EACH{head ↦ PREPEND-ELEMENT{ ↤ CREATE-ELEMENT{meta} | SET-ATTR{name ↤ 'title' } } | FOR-EACH{meta[name='title'] ↦ SET-ATTR{content ↤ QUERY-PARENT{title} | GET-TEXT-CONTENT } } }";
+
+    let mut input = Box::new(
+        r#"<html>
+    <head>
+        <title>This is the title</title>
+    </head>
+    <body>
+        <h1>Title</h1>
+    </body>
+</html>"#
+            .as_bytes(),
+    );
+    let mut output = Vec::new();
+    let hse = HtmlStreamingEditor::new(&mut input, &mut output);
+
+    let _ = hse.run(command)?;
+    let result_string = String::from_utf8(output).unwrap();
+
+    assert_eq!(
+        result_string,
+        String::from(
+            r#"<html>
+    <head><meta content="This is the title" name="title">
+        <title>This is the title</title>
+    </head>
+    <body>
+        <h1>Title</h1>
+    </body>
+</html>"#
+        )
+    );
+
+    Ok(())
+}

--- a/tests/prepend_text_content.rs
+++ b/tests/prepend_text_content.rs
@@ -16,53 +16,29 @@ const HTML_INPUT: &str = r#"<html>
 </html>"#;
 
 #[test]
-fn add_to_first_p_content() -> Result<(), StreamingEditorError> {
-    let command = "EXTRACT-ELEMENT{#first-para} | ADD-COMMENT{'followed by a comment'}";
-
-    let mut input = Box::new(HTML_INPUT.as_bytes());
-    let mut output = Vec::new();
-    let hse = HtmlStreamingEditor::new(&mut input, &mut output);
-
-    let _ = hse.run(command)?;
-    let result_string = String::from_utf8(output).unwrap();
-
-    assert_eq!(
-        result_string,
-        String::from(r#"<p id="first-para">Some first text<!-- followed by a comment --></p>"#)
-    );
-
-    Ok(())
-}
-
-#[test]
-fn add_to_ul() -> Result<(), StreamingEditorError> {
-    let command = "EXTRACT-ELEMENT{ul} | ADD-COMMENT{'Foo'}";
-
-    let mut input = Box::new(HTML_INPUT.as_bytes());
-    let mut output = Vec::new();
-    let hse = HtmlStreamingEditor::new(&mut input, &mut output);
-
-    let _ = hse.run(command)?;
-    let result_string = String::from_utf8(output).unwrap();
-
-    assert_eq!(
-        result_string,
-        String::from(
-            r#"<ul id="list">
-            <li id="item-1">1</li>
-            <li id="item-2">2</li>
-            <li id="item-3">3</li>
-        <!-- Foo --></ul>"#
-        )
-    );
-
-    Ok(())
-}
-
-#[test]
-fn add_double_dash_will_be_escaped() -> Result<(), StreamingEditorError> {
+fn prepend_to_first_p_content() -> Result<(), StreamingEditorError> {
     let command =
-        "EXTRACT-ELEMENT{#first-para} | ADD-COMMENT{'Actually -- is illegal in comments'}";
+        "EXTRACT-ELEMENT{#first-para} | PREPEND-TEXT-CONTENT{'... expanded by other text'}";
+
+    let mut input = Box::new(HTML_INPUT.as_bytes());
+    let mut output = Vec::new();
+    let hse = HtmlStreamingEditor::new(&mut input, &mut output);
+
+    let _ = hse.run(command)?;
+    let result_string = String::from_utf8(output).unwrap();
+
+    assert_eq!(
+        result_string,
+        String::from(r#"<p id="first-para">... expanded by other textSome first text</p>"#)
+    );
+
+    Ok(())
+}
+
+#[test]
+fn prepend_escape_needing_content() -> Result<(), StreamingEditorError> {
+    let command =
+        "EXTRACT-ELEMENT{#first-para} | PREPEND-TEXT-CONTENT{' is > others < & you never know which'}";
 
     let mut input = Box::new(HTML_INPUT.as_bytes());
     let mut output = Vec::new();
@@ -74,7 +50,7 @@ fn add_double_dash_will_be_escaped() -> Result<(), StreamingEditorError> {
     assert_eq!(
         result_string,
         String::from(
-            r#"<p id="first-para">Some first text<!-- Actually \x2D\x2D is illegal in comments --></p>"#
+            r#"<p id="first-para"> is &gt; others &lt; &amp; you never know whichSome first text</p>"#
         )
     );
 
@@ -82,8 +58,8 @@ fn add_double_dash_will_be_escaped() -> Result<(), StreamingEditorError> {
 }
 
 #[test]
-fn add_ul_id_as_comment_to_first_para() -> Result<(), StreamingEditorError> {
-    let command = "FOR-EACH{#first-para ↦ ADD-COMMENT{ QUERY-PARENT{ul} | GET-ATTR{id} } }";
+fn prepend_ul_id_as_text_to_first_para() -> Result<(), StreamingEditorError> {
+    let command = "FOR-EACH{#first-para ↦ PREPEND-TEXT-CONTENT{' and ul-id is: '} | PREPEND-TEXT-CONTENT{ QUERY-PARENT{ul} | GET-ATTR{id} } }";
 
     let mut input = Box::new(HTML_INPUT.as_bytes());
     let mut output = Vec::new();
@@ -99,7 +75,7 @@ fn add_ul_id_as_comment_to_first_para() -> Result<(), StreamingEditorError> {
     <head></head>
     <body>
         <h1>Title</h1>
-        <p id="first-para">Some first text<!-- list --></p>
+        <p id="first-para">list and ul-id is: Some first text</p>
         <p id="second-para">Some more text, even with an <img src=""></p>
         <p id="third-para">Third text of <abbr>HTML</abbr>, but no <abbr>CSS</abbr></p>
         <ul id="list">


### PR DESCRIPTION
⚠️ CONTAINS BREAKING CHANGE ⚠️

The following commands have been removed:
- `ADD-ELEMENT`
- `ADD-COMMENT`
- `ADD-TEXT-CONTENT`

Instead there are following, new commands:
- `APPEND-ELEMENT`: same behaviour as previous `ADD-ELEMENT`
- `APPEND-COMMENT`: same behaviour as previous `ADD-COMMENT `
- `APPEND-TEXT-CONTENT`: same behaviour as previous `ADD-TEXT-CONTENT `
- `PREPEND-ELEMENT`: similar to `APPEND-ELEMENT`, but new element is added as _first_ child
- `PREPEND-COMMENT`: similar to `APPEND-COMMENT`, but new comment is added as _first_ child
- `PREPEND-TEXT-CONTENT`: similar to `APPEND-TEXT-CONTENT`, but new text content is added as _first_ child