### PR TITLE
Support CRLF Newline

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "html-streaming-editor"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 authors = [":kelko: <kelko@me.com>"]
 repository = "https://github.com/kelko/html-streaming-editor"

--- a/src/parsing/mod.rs
+++ b/src/parsing/mod.rs
@@ -32,7 +32,7 @@ fn build_css_path<'a>(
 parser! {
   pub grammar grammar() for str {
         rule whitespace()
-            = quiet!{[' ' | '\n' | '\t']+}
+            = quiet!{([' ' | '\n' | '\t'] / "\r\n")+}
         rule pipeline_marker()
             = whitespace()? "|" whitespace()?
         rule assign_marker()

--- a/src/parsing/tests.rs
+++ b/src/parsing/tests.rs
@@ -110,6 +110,22 @@ fn parse_pipeline_with_newlines_and_whitespaces() {
 }
 
 #[test]
+fn parse_pipeline_with_crlf_newlines() {
+    let parsed = super::grammar::pipeline("EXTRACT-ELEMENT{a}\r\n| REMOVE-ELEMENT{b}");
+    assert_eq!(
+        parsed,
+        Ok(ElementProcessingPipeline::new(vec![
+            ElementProcessingCommand::ExtractElement(CssSelectorList::new(vec![
+                CssSelectorPath::single(CssSelector::for_element("a"))
+            ])),
+            ElementProcessingCommand::RemoveElement(CssSelectorList::new(vec![
+                CssSelectorPath::single(CssSelector::for_element("b"))
+            ])),
+        ]))
+    );
+}
+
+#[test]
 fn parse_extract_element() {
     let parsed = super::grammar::element_processing_command("EXTRACT-ELEMENT{a}");
     assert_eq!(


### PR DESCRIPTION
Additionally to simple space, tab and Unix new line (\n) also support Windows new line (\r\n) wherever whitespaces are supported